### PR TITLE
Added README to array list

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -16,8 +16,9 @@ This repository contains various data structures implemented in C programming la
 2. [Doubly Linked List](./doubly_linked_list): Implementation of a doubly linked list.
 3. [Circular Linked List](./circular_linked_list): Implementation of a circular linked list.
 4. [Doubly Circular Linked List](./doubly_circular_linked_list): Implementation of a doubly circular linked list.
-5. [Queue](./queue): Implementation of a queue.
-5. [Stack](./stack): Implementation of a stack.
+5. [Array List](./array_list): Implementation of a array list.
+6. [Queue](./queue): Implementation of a queue.
+7. [Stack](./stack): Implementation of a stack.
 
 Each folder contains detailed explanations, source code, and usage examples for the respective data structure.
 
@@ -49,7 +50,7 @@ To add a new data structure, you need to follow a set of rules.
 
 5. Inside the folder, create a subfolder named test.
 
-6. Inside the test subfolder, create a .c file with the name chosen in step 2, appending _test to the end of the filename.
+6. Inside the test subfolder, create a .c file with the name chosen in step 2, appending \_test to the end of the filename.
 
 For example, if you choose `linked_list` in step 2, you will create the `linked_list/` folder. Inside `linked_list/`, you will have two files, `linked_list.h` and `linked_list.c.` In addition to these files, there is a `test/` folder. Inside `test/`, you will find `linked_list_test.c.`
 
@@ -77,11 +78,13 @@ When you make code changes, follow these steps:
 ```bash
 $docker compose up --build
 ```
+
 If you have already run the previous command and haven't made further code changes, you can run:
 
 ```bash
 $docker compose up
 ```
+
 If, for some reason, you don't see the output of ctest after running the first command, you can check the information with:
 
 ```bash

--- a/array_list/README.MD
+++ b/array_list/README.MD
@@ -1,0 +1,41 @@
+# Array List in C
+
+This is a simple implementation of a array list in C. It provides basic operations to create, and manipulate list.
+
+## Table of Contents
+
+- [Introduction](#introduction)
+- [Usage](#usage)
+- [Contributing](#contributing)
+
+## Introduction
+
+This C program implements a array list with the following components:
+
+- `TArrayList`: A structure representing the array list itself.
+- Various functions to perform operations on the array list.
+
+## Usage
+
+To use this implementation of a array list in your C program, follow these steps:
+
+1. Include the `array_list.h` header file in your C source code.
+
+2. Create a array list using the `create_array_list(x)` function:
+
+   ```c
+   TArrayList *array_list = create_array_list(0);
+   ```
+
+Use the provided functions to perform operations on the list, such as inserting, removing, and printing elements.
+
+3. Clear the list and free any allocated memory when you're done using it:
+
+   ```c
+   clear(array_list);
+   ```
+
+For more details on available functions and how to use them, refer to the comments in the `array_list.h` file.
+
+## Contributing
+Contributions are welcome! If you have any improvements, bug fixes, or feature additions, feel free to open an issue or submit a pull request.


### PR DESCRIPTION
I have added the `README` file that describes how to use the array list. It follows the same pattern as the `READMEs` of the other data structures in this repository. 
Additionally, I have added a new item in the repository's `README` that showcases the array list among the data structures.